### PR TITLE
Link to right autobuild by filtering out release builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
 	};
 
 	// run a request to Azure to get the latest dev/beta/stable IDs, to turn the download links into direct links.
-	xhttpEverest.open("GET", "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds", true);
+	xhttpEverest.open("GET", "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds?definitions=3", true);
 	xhttpEverest.send();
 
 	// now let's do the same for Olympus


### PR DESCRIPTION
This is the same fix as https://github.com/EverestAPI/Everest/commit/ae047c32ed43d7eaff5fd42eaaa7b7b62b54cf5e but for the website. The link to the latest devbuild leads to a 404 page on the site right now...