### PR TITLE
Improve Linux install documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
                             <li>Unzip the zip inside of the zip. Zipception!<br>
                                 <b>The resulting folder will be your Olympus "installation" folder.</b>
                             </li>
-                            <li>Run <code>install.sh</code> to install the one-click installer handler and application icon.</li>
+                            <li>Run <code>install.sh</code> <b>in a terminal</b> to install the one-click installer handler and application icon.</li>
                             <li>
                                 Run Olympus from your applications list (or <code>olympus</code> in the folder) and hope that it works.<br>
                                 If the bundled Love2D doesn't work and your distro provides it via the package manager, try that.<br>


### PR DESCRIPTION
Several people in the Celeste Discord have had issues with the Linux installation because they ran the `install.sh` script from their file explorer instead of a terminal. This PR adds this requirement to the installation guide.