### PR TITLE
Use Everest versions list API to fetch latest Everest versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,71 +1,41 @@
-{
-	// this looks ugly, but filter(version => version.sourceBranch === branch) gives a syntax error on IE 11.
-	// this code works on IE 10 and later.
-	function extractVersionsList(json, branch) {
-		return json.value
-			.filter(function(version) { return version.sourceBranch === branch; })
-			.map(function(version) { return version.id; });
-	}
+(async () => {
+    // gives the download link for a given branch once the Everest version list was fetched, or null if no build was found
+    const getLinkForBranch = (versionList, branch) => {
+        const matchingVersions = versionList.filter(version => version.branch === branch);
 
-	var xhttpEverest = new XMLHttpRequest();
-	xhttpEverest.onreadystatechange = function() {
-		if (this.readyState == 4 && this.status == 200) {
-			// parse the response
-			var json = JSON.parse(this.responseText);
+        if (matchingVersions.length !== 0) {
+            return matchingVersions[0].mainDownload;
+        }
+        return null;
+    };
 
-			// get the dev, beta and stable build IDs
-			var devVersions = extractVersionsList(json, "refs/heads/dev");
-			var betaVersions = extractVersionsList(json, "refs/heads/beta");
-			var stableVersions = extractVersionsList(json, "refs/heads/stable");
+    // a static file on this website indicates to Everest and Olympus where the Everest versions list is provided,
+    // so load the URL from there as well...
+    const updaterUrlFetch = await fetch("/everestupdater.txt");
 
-			// if both are present...
-			if (devVersions.length !== 0 && betaVersions.length !== 0 && stableVersions.length !== 0) {
-				// set the links to their artifacts
-				document.getElementById("latest-dev-link").href = "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds/" + devVersions[0] + "/artifacts?artifactName=main&$format=zip"
-				document.getElementById("latest-beta-link").href = "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds/" + betaVersions[0] + "/artifacts?artifactName=main&$format=zip"
-				document.getElementById("latest-stable-link").href = "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds/" + stableVersions[0] + "/artifacts?artifactName=main&$format=zip"
+    if (updaterUrlFetch.ok) {
+        // ... then call it.
+        const updaterUrl = await updaterUrlFetch.text();
+        const versionListFetch = await fetch(updaterUrl.trim());
 
-				// remove the line saying "Click the '1 published' button under 'Related', then 'main' to download it." since those are now direct links.
-				var artifactInstructions = document.getElementById("artifact-instructions");
-				artifactInstructions.parentNode.removeChild(artifactInstructions);
-			}
-		}
-	};
+        if (versionListFetch.ok) {
+            const versionList = await versionListFetch.json();
 
-	// run a request to Azure to get the latest dev/beta/stable IDs, to turn the download links into direct links.
-	xhttpEverest.open("GET", "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds?definitions=3", true);
-	xhttpEverest.send();
+            const stable = getLinkForBranch(versionList, "stable");
+            const beta = getLinkForBranch(versionList, "beta");
+            const dev = getLinkForBranch(versionList, "dev");
 
-	// now let's do the same for Olympus
+            // if all versions have an existing build...
+            if (stable !== null && beta !== null && dev !== null) {
+                // set the links to their artifacts
+                document.getElementById("latest-stable-link").href = stable;
+                document.getElementById("latest-beta-link").href = beta;
+                document.getElementById("latest-dev-link").href = dev;
 
-	var xhttpEverest = new XMLHttpRequest();
-	xhttpEverest.onreadystatechange = function() {
-		if (this.readyState == 4 && this.status == 200) {
-			// parse the response
-			var json = JSON.parse(this.responseText);
-
-			// get the stable, main and dev build IDs
-			var stableVersions = extractVersionsList(json, "refs/heads/stable");
-			var mainVersions = extractVersionsList(json, "refs/heads/main");
-			var devVersions = extractVersionsList(json, "refs/heads/dev");
-
-			// grab whichever exists
-			var id = stableVersions[0] || mainVersions[0] || devVersions[0]
-			if (id) {
-				// set the links to their artifacts
-				document.getElementById("olympus-macos-latest-link").href = "https://dev.azure.com/EverestAPI/Olympus/_apis/build/builds/" + id + "/artifacts?artifactName=macos.main&$format=zip"
-				document.getElementById("olympus-linux-latest-link").href = "https://dev.azure.com/EverestAPI/Olympus/_apis/build/builds/" + id + "/artifacts?artifactName=linux.main&$format=zip"
-
-				// remove the line saying "Click the '5 published' button under 'Related', then '...main' to download it." since those are now direct links.
-				var artifactInstructions = document.getElementById("olympus-macos-artifact-instructions");
-				artifactInstructions.parentNode.removeChild(artifactInstructions);
-				artifactInstructions = document.getElementById("olympus-linux-artifact-instructions");
-				artifactInstructions.parentNode.removeChild(artifactInstructions);
-			}
-		}
-	};
-
-	// run a request to Azure to get the latest stable/main/dev IDs, to turn the download links into direct links.
-	xhttpEverest.open("GET", "https://dev.azure.com/EverestAPI/Olympus/_apis/build/builds", true);
-	xhttpEverest.send();
-}
+                // remove the line saying "Click the '1 published' button under 'Related', then 'main' to download it." since those are now direct links.
+                var artifactInstructions = document.getElementById("artifact-instructions");
+                artifactInstructions.parentNode.removeChild(artifactInstructions);
+            }
+        }
+    }
+})();


### PR DESCRIPTION
Much like https://github.com/EverestAPI/Olympus/pull/43 does for Olympus, this PR plugs the website to the Everest versions list API.